### PR TITLE
Wall color in comparedisp

### DIFF
--- a/CompareDisp.v
+++ b/CompareDisp.v
@@ -50,7 +50,8 @@ input  [31:0] player_hOffset ,
 
 
 input [3:0] player_color,
-input [3:0] wall_color,
+input [3:0] wall_color [3:0][5:0],
+input [3:0] scroll_color [3:0][5:0],
 
 output reg [2:0] Sel
 );
@@ -88,22 +89,22 @@ begin
             //object 1 
     else if(hCount<=wall_hStartPos[0][0]+h+wall_hOffset[0][0]+wall_objWidth[0][0]&&hCount>=wall_hStartPos[0][0]+h+wall_hOffset[0][0]&&vCount<=wall_vStartPos[0][0]+v+wall_vOffset[0][0]+wall_objHeight[0][0]&&vCount>=wall_vStartPos[0][0]+v+wall_vOffset[0][0])
      begin
-            Sel<=6; //white
+            Sel<=wall_color[0][0]; //white
     end 
     //object 2
     else if(hCount<=wall_hStartPos[1][0]+h+wall_hOffset[1][0]+wall_objWidth[1][0]&&hCount>=wall_hStartPos[1][0]+h+wall_hOffset[1][0]&&vCount<=wall_vStartPos[1][0]+v+wall_vOffset[1][0]+wall_objHeight[1][0]&&vCount>=wall_vStartPos[1][0]+v+wall_vOffset[1][0])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[0][0]; //white
         end 
 //        //object 3
     else if(hCount<=wall_hStartPos[2][0]+h+wall_hOffset[2][0]+wall_objWidth[2][0]&&hCount>=wall_hStartPos[2][0]+h+wall_hOffset[2][0]&&vCount<=wall_vStartPos[2][0]+v+wall_vOffset[2][0]+wall_objHeight[2][0]&&vCount>=wall_vStartPos[2][0]+v+wall_vOffset[2][0])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[0][0]; //white
         end 
 //        //object 4
     else if(hCount<=wall_hStartPos[3][0]+h+wall_hOffset[3][0]+wall_objWidth[3][0]&&hCount>=wall_hStartPos[3][0]+h+wall_hOffset[3][0]&&vCount<=wall_vStartPos[3][0]+v+wall_vOffset[3][0]+wall_objHeight[3][0]&&vCount>=wall_vStartPos[3][0]+v+wall_vOffset[3][0])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[0][0]; //white
         end 
 
 
@@ -114,22 +115,22 @@ begin
 //WALL1
     else if(hCount<=wall_hStartPos[0][1]+h+wall_hOffset[0][1]+wall_objWidth[0][1]&&hCount>=wall_hStartPos[0][1]+h+wall_hOffset[0][1]&&vCount<=wall_vStartPos[0][1]+v+wall_vOffset[0][1]+wall_objHeight[0][1]&&vCount>=wall_vStartPos[0][1]+v+wall_vOffset[0][1])
      begin
-            Sel<=6; //white
+            Sel<=wall_color[0][1]; //white
     end 
     //object 2
     else if(hCount<=wall_hStartPos[1][1]+h+wall_hOffset[1][1]+wall_objWidth[1][1]&&hCount>=wall_hStartPos[1][1]+h+wall_hOffset[1][1]&&vCount<=wall_vStartPos[1][1]+v+wall_vOffset[1][1]+wall_objHeight[1][1]&&vCount>=wall_vStartPos[1][1]+v+wall_vOffset[1][1])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[1][1]; //white
         end 
 //        //object 3
     else if(hCount<=wall_hStartPos[2][1]+h+wall_hOffset[2][1]+wall_objWidth[2][1]&&hCount>=wall_hStartPos[2][1]+h+wall_hOffset[2][1]&&vCount<=wall_vStartPos[2][1]+v+wall_vOffset[2][1]+wall_objHeight[2][1]&&vCount>=wall_vStartPos[2][1]+v+wall_vOffset[2][1])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[2][1]; //white
         end 
 //        //object 4
     else if(hCount<=wall_hStartPos[3][1]+h+wall_hOffset[3][1]+wall_objWidth[3][1]&&hCount>=wall_hStartPos[3][1]+h+wall_hOffset[3][1]&&vCount<=wall_vStartPos[3][1]+v+wall_vOffset[3][1]+wall_objHeight[3][1]&&vCount>=wall_vStartPos[3][1]+v+wall_vOffset[3][1])
         begin
-            Sel<=6; //white
+            Sel<=wall_color[3][1]; //white
         end 
 
 
@@ -139,85 +140,85 @@ begin
 
 //WALL 2
     else if(hCount<=wall_hStartPos[0][2]+h+wall_hOffset[0][2]+wall_objWidth[0][2]&&hCount>=wall_hStartPos[0][2]+h+wall_hOffset[0][2]&&vCount<=wall_vStartPos[0][2]+v+wall_vOffset[0][2]+wall_objHeight[0][2]&&vCount>=wall_vStartPos[0][2]+v+wall_vOffset[0][2])
-     begin
-                                Sel<=6; //white
-    end 
+        begin
+            Sel<=wall_color[0][2]; //white
+        end 
     //object 2
     else if(hCount<=wall_hStartPos[1][2]+h+wall_hOffset[1][2]+wall_objWidth[1][2]&&hCount>=wall_hStartPos[1][2]+h+wall_hOffset[1][2]&&vCount<=wall_vStartPos[1][2]+v+wall_vOffset[1][2]+wall_objHeight[1][2]&&vCount>=wall_vStartPos[1][2]+v+wall_vOffset[1][2])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[1][2]; //white
         end 
 //        //object 3
     else if(hCount<=wall_hStartPos[2][2]+h+wall_hOffset[2][2]+wall_objWidth[2][2]&&hCount>=wall_hStartPos[2][2]+h+wall_hOffset[2][2]&&vCount<=wall_vStartPos[2][2]+v+wall_vOffset[2][2]+wall_objHeight[2][2]&&vCount>=wall_vStartPos[2][2]+v+wall_vOffset[2][2])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[2][2]; //white
         end 
 //        //object 4
     else if(hCount<=wall_hStartPos[3][2]+h+wall_hOffset[3][2]+wall_objWidth[3][2]&&hCount>=wall_hStartPos[3][2]+h+wall_hOffset[3][2]&&vCount<=wall_vStartPos[3][2]+v+wall_vOffset[3][2]+wall_objHeight[3][2]&&vCount>=wall_vStartPos[3][2]+v+wall_vOffset[3][2])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[3][2]; //white
         end 
 
 // WALL 3
     else if(hCount<=wall_hStartPos[0][3]+h+wall_hOffset[0][3]+wall_objWidth[0][3]&&hCount>=wall_hStartPos[0][3]+h+wall_hOffset[0][3]&&vCount<=wall_vStartPos[0][3]+v+wall_vOffset[0][3]+wall_objHeight[0][3]&&vCount>=wall_vStartPos[0][3]+v+wall_vOffset[0][3])
      begin
-                                Sel<=6; //white
+            Sel<=wall_color[0][3]; //white
     end 
     //object 2
     else if(hCount<=wall_hStartPos[1][3]+h+wall_hOffset[1][3]+wall_objWidth[1][3]&&hCount>=wall_hStartPos[1][3]+h+wall_hOffset[1][3]&&vCount<=wall_vStartPos[1][3]+v+wall_vOffset[1][3]+wall_objHeight[1][3]&&vCount>=wall_vStartPos[1][3]+v+wall_vOffset[1][3])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[1][3]; //white
         end 
 //        //object 3
     else if(hCount<=wall_hStartPos[2][3]+h+wall_hOffset[2][3]+wall_objWidth[2][3]&&hCount>=wall_hStartPos[2][3]+h+wall_hOffset[2][3]&&vCount<=wall_vStartPos[2][3]+v+wall_vOffset[2][3]+wall_objHeight[2][3]&&vCount>=wall_vStartPos[2][3]+v+wall_vOffset[2][3])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[2][3]; //white
         end 
 //        //object 4
     else if(hCount<=wall_hStartPos[3][3]+h+wall_hOffset[3][3]+wall_objWidth[3][3]&&hCount>=wall_hStartPos[3][3]+h+wall_hOffset[3][3]&&vCount<=wall_vStartPos[3][3]+v+wall_vOffset[3][3]+wall_objHeight[3][3]&&vCount>=wall_vStartPos[3][3]+v+wall_vOffset[3][3])
         begin
-                                Sel<=6; //white
+            Sel<=wall_color[3][3]; //white
         end 
         
 // WALL 4
                 else if(hCount<=wall_hStartPos[0][4]+h+wall_hOffset[0][4]+wall_objWidth[0][4]&&hCount>=wall_hStartPos[0][4]+h+wall_hOffset[0][4]&&vCount<=wall_vStartPos[0][4]+v+wall_vOffset[0][4]+wall_objHeight[0][4]&&vCount>=wall_vStartPos[0][4]+v+wall_vOffset[0][4])
                  begin
-                                Sel<=6; //white
+                    Sel<=wall_color[0][4]; //white
                 end 
                 //object 2
                 else if(hCount<=wall_hStartPos[1][4]+h+wall_hOffset[1][4]+wall_objWidth[1][4]&&hCount>=wall_hStartPos[1][4]+h+wall_hOffset[1][4]&&vCount<=wall_vStartPos[1][4]+v+wall_vOffset[1][4]+wall_objHeight[1][4]&&vCount>=wall_vStartPos[1][4]+v+wall_vOffset[1][4])
                     begin
-                                Sel<=6; //white
+                    Sel<=wall_color[1][4]; //white
                     end 
         //        //object 3
                 else if(hCount<=wall_hStartPos[2][4]+h+wall_hOffset[2][4]+wall_objWidth[2][4]&&hCount>=wall_hStartPos[2][4]+h+wall_hOffset[2][4]&&vCount<=wall_vStartPos[2][4]+v+wall_vOffset[2][4]+wall_objHeight[2][4]&&vCount>=wall_vStartPos[2][4]+v+wall_vOffset[2][4])
                     begin
-                                Sel<=6; //white
+                    Sel<=wall_color[2][4]; //white
                     end 
         //        //object 4
                 else if(hCount<=wall_hStartPos[3][4]+h+wall_hOffset[3][4]+wall_objWidth[3][4]&&hCount>=wall_hStartPos[3][4]+h+wall_hOffset[3][4]&&vCount<=wall_vStartPos[3][4]+v+wall_vOffset[3][4]+wall_objHeight[3][4]&&vCount>=wall_vStartPos[3][4]+v+wall_vOffset[3][4])
                     begin
-                                Sel<=6; //white
+                    Sel<=wall_color[3][4]; //white
                     end 
 // WALL 5
                 else if(hCount<=wall_hStartPos[0][5]+h+wall_hOffset[0][5]+wall_objWidth[0][5]&&hCount>=wall_hStartPos[0][5]+h+wall_hOffset[0][5]&&vCount<=wall_vStartPos[0][5]+v+wall_vOffset[0][5]+wall_objHeight[0][5]&&vCount>=wall_vStartPos[0][5]+v+wall_vOffset[0][5])
                  begin
-                                Sel<=6; //white
+                    Sel<=wall_color[0][5]; //white
                 end 
                 //object 2
                 else if(hCount<=wall_hStartPos[1][5]+h+wall_hOffset[1][5]+wall_objWidth[1][5]&&hCount>=wall_hStartPos[1][5]+h+wall_hOffset[1][5]&&vCount<=wall_vStartPos[1][5]+v+wall_vOffset[1][5]+wall_objHeight[1][5]&&vCount>=wall_vStartPos[1][5]+v+wall_vOffset[1][5])
                     begin
-                                Sel<=6; //white
+                        Sel<=wall_color[1][5]; //white
                     end 
         //        //object 3
                 else if(hCount<=wall_hStartPos[2][5]+h+wall_hOffset[2][5]+wall_objWidth[2][5]&&hCount>=wall_hStartPos[2][5]+h+wall_hOffset[2][5]&&vCount<=wall_vStartPos[2][5]+v+wall_vOffset[2][5]+wall_objHeight[2][5]&&vCount>=wall_vStartPos[2][5]+v+wall_vOffset[2][5])
                     begin
-                                Sel<=6; //white
+                        Sel<=wall_color[2][5]; //white
                     end 
         //        //object 4
                 else if(hCount<=wall_hStartPos[3][5]+h+wall_hOffset[3][5]+wall_objWidth[3][5]&&hCount>=wall_hStartPos[3][5]+h+wall_hOffset[3][5]&&vCount<=wall_vStartPos[3][5]+v+wall_vOffset[3][5]+wall_objHeight[3][5]&&vCount>=wall_vStartPos[3][5]+v+wall_vOffset[3][5])
                     begin
-                                Sel<=6; //white
+                        Sel<=wall_color[3][5]; //white
                     end 
 //======================================================================================                    
 //SROLLS
@@ -226,22 +227,22 @@ begin
                                 //object 1 
                         else if(hCount<=hStartPos[0][0]+h+hOffset[0][0]+objWidth[0][0]&&hCount>=hStartPos[0][0]+h+hOffset[0][0]&&vCount<=vStartPos[0][0]+v+vOffset[0][0]+objHeight[0][0]&&vCount>=vStartPos[0][0]+v+vOffset[0][0])
                          begin
-                                Sel<=2; //white
+                                Sel<=scroll_color[0][0]; 
                         end 
                         //object 2
                         else if(hCount<=hStartPos[1][0]+h+hOffset[1][0]+objWidth[1][0]&&hCount>=hStartPos[1][0]+h+hOffset[1][0]&&vCount<=vStartPos[1][0]+v+vOffset[1][0]+objHeight[1][0]&&vCount>=vStartPos[1][0]+v+vOffset[1][0])
                             begin
-                                Sel<=3; //white
+                                Sel<=scroll_color[1][0]; 
                             end 
                     //        //object 3
                         else if(hCount<=hStartPos[2][0]+h+hOffset[2][0]+objWidth[2][0]&&hCount>=hStartPos[2][0]+h+hOffset[2][0]&&vCount<=vStartPos[2][0]+v+vOffset[2][0]+objHeight[2][0]&&vCount>=vStartPos[2][0]+v+vOffset[2][0])
                             begin
-                                Sel<=4; //white
+                                Sel<=scroll_color[2][0]; 
                             end 
                     //        //object 4
                         else if(hCount<=hStartPos[3][0]+h+hOffset[3][0]+objWidth[3][0]&&hCount>=hStartPos[3][0]+h+hOffset[3][0]&&vCount<=vStartPos[3][0]+v+vOffset[3][0]+objHeight[3][0]&&vCount>=vStartPos[3][0]+v+vOffset[3][0])
                             begin
-                                Sel<=5; //white
+                                Sel<=scroll_color[3][0]; 
                             end 
                     
                     
@@ -252,22 +253,22 @@ begin
                     //SCROLL1
                         else if(hCount<=hStartPos[0][1]+h+hOffset[0][1]+objWidth[0][1]&&hCount>=hStartPos[0][1]+h+hOffset[0][1]&&vCount<=vStartPos[0][1]+v+vOffset[0][1]+objHeight[0][1]&&vCount>=vStartPos[0][1]+v+vOffset[0][1])
                          begin
-                            Sel<=2; //red
+                                Sel<=scroll_color[0][1]; 
                         end 
                         //object 2
                         else if(hCount<=hStartPos[1][1]+h+hOffset[1][1]+objWidth[1][1]&&hCount>=hStartPos[1][1]+h+hOffset[1][1]&&vCount<=vStartPos[1][1]+v+vOffset[1][1]+objHeight[1][1]&&vCount>=vStartPos[1][1]+v+vOffset[1][1])
                             begin
-                                Sel<=3; //cyan
+                                Sel<=scroll_color[1][1]; 
                             end 
                     //        //object 3
                         else if(hCount<=hStartPos[2][1]+h+hOffset[2][1]+objWidth[2][1]&&hCount>=hStartPos[2][1]+h+hOffset[2][1]&&vCount<=vStartPos[2][1]+v+vOffset[2][1]+objHeight[2][1]&&vCount>=vStartPos[2][1]+v+vOffset[2][1])
                             begin
-                                Sel<=4; //yellow
+                                Sel<=scroll_color[2][1]; 
                             end 
                     //        //object 4
                         else if(hCount<=hStartPos[3][1]+h+hOffset[3][1]+objWidth[3][1]&&hCount>=hStartPos[3][1]+h+hOffset[3][1]&&vCount<=vStartPos[3][1]+v+vOffset[3][1]+objHeight[3][1]&&vCount>=vStartPos[3][1]+v+vOffset[3][1])
                             begin
-                                Sel<=5; //magenta
+                                Sel<=scroll_color[3][1]; 
                             end 
                     
                     
@@ -278,84 +279,84 @@ begin
                     //SCROLL 2
                         else if(hCount<=hStartPos[0][2]+h+hOffset[0][2]+objWidth[0][2]&&hCount>=hStartPos[0][2]+h+hOffset[0][2]&&vCount<=vStartPos[0][2]+v+vOffset[0][2]+objHeight[0][2]&&vCount>=vStartPos[0][2]+v+vOffset[0][2])
                          begin
-                            Sel<=2; //red
+                                Sel<=scroll_color[0][2]; 
                         end 
                         //object 2
                         else if(hCount<=hStartPos[1][2]+h+hOffset[1][2]+objWidth[1][2]&&hCount>=hStartPos[1][2]+h+hOffset[1][2]&&vCount<=vStartPos[1][2]+v+vOffset[1][2]+objHeight[1][2]&&vCount>=vStartPos[1][2]+v+vOffset[1][2])
                             begin
-                                Sel<=3; //cyan
+                                Sel<=scroll_color[1][2]; 
                             end 
                     //        //object 3
                         else if(hCount<=hStartPos[2][2]+h+hOffset[2][2]+objWidth[2][2]&&hCount>=hStartPos[2][2]+h+hOffset[2][2]&&vCount<=vStartPos[2][2]+v+vOffset[2][2]+objHeight[2][2]&&vCount>=vStartPos[2][2]+v+vOffset[2][2])
                             begin
-                                Sel<=4; //yellow
+                                Sel<=scroll_color[2][2]; 
                             end 
                     //        //object 4
                         else if(hCount<=hStartPos[3][2]+h+hOffset[3][2]+objWidth[3][2]&&hCount>=hStartPos[3][2]+h+hOffset[3][2]&&vCount<=vStartPos[3][2]+v+vOffset[3][2]+objHeight[3][2]&&vCount>=vStartPos[3][2]+v+vOffset[3][2])
                             begin
-                                Sel<=5; //magenta
+                                Sel<=scroll_color[3][2]; 
                             end 
                     
                     // SCROLL 3
                         else if(hCount<=hStartPos[0][3]+h+hOffset[0][3]+objWidth[0][3]&&hCount>=hStartPos[0][3]+h+hOffset[0][3]&&vCount<=vStartPos[0][3]+v+vOffset[0][3]+objHeight[0][3]&&vCount>=vStartPos[0][3]+v+vOffset[0][3])
                          begin
-                            Sel<=2; //red
+                                Sel<=scroll_color[0][3]; 
                         end 
                         //object 2
                         else if(hCount<=hStartPos[1][3]+h+hOffset[1][3]+objWidth[1][3]&&hCount>=hStartPos[1][3]+h+hOffset[1][3]&&vCount<=vStartPos[1][3]+v+vOffset[1][3]+objHeight[1][3]&&vCount>=vStartPos[1][3]+v+vOffset[1][3])
                             begin
-                                Sel<=3; //cyan
+                                Sel<=scroll_color[1][3]; 
                             end 
                     //        //object 3
                         else if(hCount<=hStartPos[2][3]+h+hOffset[2][3]+objWidth[2][3]&&hCount>=hStartPos[2][3]+h+hOffset[2][3]&&vCount<=vStartPos[2][3]+v+vOffset[2][3]+objHeight[2][3]&&vCount>=vStartPos[2][3]+v+vOffset[2][3])
                             begin
-                                Sel<=4; //yellow
+                                Sel<=scroll_color[2][3]; 
                             end 
                     //        //object 4
                         else if(hCount<=hStartPos[3][3]+h+hOffset[3][3]+objWidth[3][3]&&hCount>=hStartPos[3][3]+h+hOffset[3][3]&&vCount<=vStartPos[3][3]+v+vOffset[3][3]+objHeight[3][3]&&vCount>=vStartPos[3][3]+v+vOffset[3][3])
                             begin
-                                Sel<=5; //magenta
+                                Sel<=scroll_color[3][3]; 
                             end 
                             
                     // SCROLL 4
                                     else if(hCount<=hStartPos[0][4]+h+hOffset[0][4]+objWidth[0][4]&&hCount>=hStartPos[0][4]+h+hOffset[0][4]&&vCount<=vStartPos[0][4]+v+vOffset[0][4]+objHeight[0][4]&&vCount>=vStartPos[0][4]+v+vOffset[0][4])
                                      begin
-                                        Sel<=2; //red
+                                Sel<=scroll_color[0][4]; 
                                     end 
                                     //object 2
                                     else if(hCount<=hStartPos[1][4]+h+hOffset[1][4]+objWidth[1][4]&&hCount>=hStartPos[1][4]+h+hOffset[1][4]&&vCount<=vStartPos[1][4]+v+vOffset[1][4]+objHeight[1][4]&&vCount>=vStartPos[1][4]+v+vOffset[1][4])
                                         begin
-                                            Sel<=3; //cyan
+                                Sel<=scroll_color[1][4]; 
                                         end 
                             //        //object 3
                                     else if(hCount<=hStartPos[2][4]+h+hOffset[2][4]+objWidth[2][4]&&hCount>=hStartPos[2][4]+h+hOffset[2][4]&&vCount<=vStartPos[2][4]+v+vOffset[2][4]+objHeight[2][4]&&vCount>=vStartPos[2][4]+v+vOffset[2][4])
                                         begin
-                                            Sel<=4; //yellow
+                                Sel<=scroll_color[2][4]; 
                                         end 
                             //        //object 4
                                     else if(hCount<=hStartPos[3][4]+h+hOffset[3][4]+objWidth[3][4]&&hCount>=hStartPos[3][4]+h+hOffset[3][4]&&vCount<=vStartPos[3][4]+v+vOffset[3][4]+objHeight[3][4]&&vCount>=vStartPos[3][4]+v+vOffset[3][4])
                                         begin
-                                            Sel<=5; //magenta
+                                Sel<=scroll_color[3][4]; 
                                         end 
                     // SCROLL 5
                                     else if(hCount<=hStartPos[0][5]+h+hOffset[0][5]+objWidth[0][5]&&hCount>=hStartPos[0][5]+h+hOffset[0][5]&&vCount<=vStartPos[0][5]+v+vOffset[0][5]+objHeight[0][5]&&vCount>=vStartPos[0][5]+v+vOffset[0][5])
                                      begin
-                                        Sel<=2; //red
+                                        Sel<=scroll_color[0][5]; 
                                     end 
                                     //object 2
                                     else if(hCount<=hStartPos[1][5]+h+hOffset[1][5]+objWidth[1][5]&&hCount>=hStartPos[1][5]+h+hOffset[1][5]&&vCount<=vStartPos[1][5]+v+vOffset[1][5]+objHeight[1][5]&&vCount>=vStartPos[1][5]+v+vOffset[1][5])
                                         begin
-                                            Sel<=3; //cyan
+                                        Sel<=scroll_color[1][5]; 
                                         end 
                             //        //object 3
                                     else if(hCount<=hStartPos[2][5]+h+hOffset[2][5]+objWidth[2][5]&&hCount>=hStartPos[2][5]+h+hOffset[2][5]&&vCount<=vStartPos[2][5]+v+vOffset[2][5]+objHeight[2][5]&&vCount>=vStartPos[2][5]+v+vOffset[2][5])
                                         begin
-                                            Sel<=4; //yellow
+                                        Sel<=scroll_color[2][5]; 
                                         end 
                             //        //object 4
                                     else if(hCount<=hStartPos[3][5]+h+hOffset[3][5]+objWidth[3][5]&&hCount>=hStartPos[3][5]+h+hOffset[3][5]&&vCount<=vStartPos[3][5]+v+vOffset[3][5]+objHeight[3][5]&&vCount>=vStartPos[3][5]+v+vOffset[3][5])
                                         begin
-                                            Sel<=5; //magenta
+                                        Sel<=scroll_color[3][5]; 
                                         end 
 
 

--- a/Game.v
+++ b/Game.v
@@ -77,12 +77,13 @@ wire [31:0] player_hOffset_w ;
 
 
 wire  [3:0] player_color_w;
-wire  [3:0] wall_color_w;
-
+wire [3:0] scroll_color_o_w [3:0][5:0];  
+wire [3:0] wall_color_o_w [3:0][5:0];  
 
 VideoController V1( 
     player_color_w, 
-    wall_color_w, 
+    wall_color_o_w, 
+     scroll_color_o_w, 
     clk, 
     rst, 
     In,
@@ -180,13 +181,12 @@ PlayerObject playerObj(
     player_color_w    
     );
           
-wire [3:0] color_o_w [3:0][5:0];  
-wire [3:0] wall_color_o_w [3:0][5:0];  
+
 
  
 // Scrolling color bars
 Scrolls G9(player_hPos_w, player_vPos_w, player_color_w, rst, btnClk_w, uBtns_w, vStartPos_w, hStartPos_w, 
-objWidth_w, objHeight_w, vOffset_w, hOffset_w, color_o_w, enableUp_w, enableDown_w, enableLeft_w, enableRight_w); 
+objWidth_w, objHeight_w, vOffset_w, hOffset_w, scroll_color_o_w, enableUp_w, enableDown_w, enableLeft_w, enableRight_w); 
 
 
 /*module Obstacles(           

--- a/Game.v
+++ b/Game.v
@@ -146,6 +146,11 @@ enableCompare G10 (
     enableLeft_w,
     enableRight_w,
     
+    wall_enableUp_w,
+    wall_enableDown_w,
+    wall_enableLeft_w,
+    wall_enableRight_w,
+    
     up_Enable_w,
     down_Enable_w,
     left_Enable_w,

--- a/Obstacles.v
+++ b/Obstacles.v
@@ -99,10 +99,10 @@ output rightEnable[3:0][5:0]
     
     
     //wall 0
-    Rectangle wall_0_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos,rect1_hStartPos,rectWidth,rectHeight,vStartPos[0][0],hStartPos[0][0],objWidth[0][0],objHeight[0][0],vOffset[0][0],hOffset[0][0], color_o[0][0], upEnable[0][0], downEnable[0][0], leftEnable[0][0], rightEnable[0][0]);
-    Rectangle wall_0_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos,rect2_hStartPos,rectWidth,rectHeight,vStartPos[1][0],hStartPos[1][0],objWidth[1][0],objHeight[1][0],vOffset[1][0],hOffset[1][0], color_o[1][0], upEnable[1][0], downEnable[1][0], leftEnable[1][0], rightEnable[1][0]);
-    Rectangle wall_0_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos,rect3_hStartPos,rectWidth,rectHeight,vStartPos[2][0],hStartPos[2][0],objWidth[2][0],objHeight[2][0],vOffset[2][0],hOffset[2][0], color_o[2][0], upEnable[2][0], downEnable[2][0], leftEnable[2][0], rightEnable[2][0]);
-    Rectangle wall_0_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos,rect4_hStartPos,rectWidth,rectHeight,vStartPos[3][0],hStartPos[3][0],objWidth[3][0],objHeight[3][0],vOffset[3][0],hOffset[3][0], color_o[3][0], upEnable[3][0], downEnable[3][0], leftEnable[3][0], rightEnable[3][0]);    
+    Rectangle wall_0_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos,rect1_hStartPos,rectWidth,rectHeight,vStartPos[0][0],hStartPos[0][0],objWidth[0][0],objHeight[0][0],vOffset[0][0],hOffset[0][0], color_o[0][0], upEnable[0][0], downEnable[0][0], leftEnable[0][0], rightEnable[0][0]);
+//    Rectangle wall_0_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos,rect2_hStartPos,rectWidth,rectHeight,vStartPos[1][0],hStartPos[1][0],objWidth[1][0],objHeight[1][0],vOffset[1][0],hOffset[1][0], color_o[1][0], upEnable[1][0], downEnable[1][0], leftEnable[1][0], rightEnable[1][0]);
+    Rectangle wall_0_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos,rect3_hStartPos,rectWidth,rectHeight,vStartPos[2][0],hStartPos[2][0],objWidth[2][0],objHeight[2][0],vOffset[2][0],hOffset[2][0], color_o[2][0], upEnable[2][0], downEnable[2][0], leftEnable[2][0], rightEnable[2][0]);
+    Rectangle wall_0_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos,rect4_hStartPos,rectWidth,rectHeight,vStartPos[3][0],hStartPos[3][0],objWidth[3][0],objHeight[3][0],vOffset[3][0],hOffset[3][0], color_o[3][0], upEnable[3][0], downEnable[3][0], leftEnable[3][0], rightEnable[3][0]);    
 
  
  //=======================================================================================
@@ -130,10 +130,10 @@ output rightEnable[3:0][5:0]
        parameter rect4_vStartPos1=wall_vOffset1;
        parameter rect4_hStartPos1=4*wall_hOffset1;    
        
-       Rectangle wall_1_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos1,rect1_hStartPos1,rectWidth,rectHeight,vStartPos[0][1],hStartPos[0][1],objWidth[0][1],objHeight[0][1],vOffset[0][1],hOffset[0][1], color_o[0][1], upEnable[0][1], downEnable[0][1], leftEnable[0][1], rightEnable[0][1]);
-       Rectangle wall_1_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos1,rect2_hStartPos1,rectWidth,rectHeight,vStartPos[1][1],hStartPos[1][1],objWidth[1][1],objHeight[1][1],vOffset[1][1],hOffset[1][1], color_o[1][1], upEnable[1][1], downEnable[1][1], leftEnable[1][1], rightEnable[1][1]);
-       Rectangle wall_1_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos1,rect3_hStartPos1,rectWidth,rectHeight,vStartPos[2][1],hStartPos[2][1],objWidth[2][1],objHeight[2][1],vOffset[2][1],hOffset[2][1], color_o[2][1], upEnable[2][1], downEnable[2][1], leftEnable[2][1], rightEnable[2][1]);
-       Rectangle wall_1_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos1,rect4_hStartPos1,rectWidth,rectHeight,vStartPos[3][1],hStartPos[3][1],objWidth[3][1],objHeight[3][1],vOffset[3][1],hOffset[3][1], color_o[3][1], upEnable[3][1], downEnable[3][1], leftEnable[3][1], rightEnable[3][1]);  
+       Rectangle wall_1_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos1,rect1_hStartPos1,rectWidth,rectHeight,vStartPos[0][1],hStartPos[0][1],objWidth[0][1],objHeight[0][1],vOffset[0][1],hOffset[0][1], color_o[0][1], upEnable[0][1], downEnable[0][1], leftEnable[0][1], rightEnable[0][1]);
+       Rectangle wall_1_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos1,rect2_hStartPos1,rectWidth,rectHeight,vStartPos[1][1],hStartPos[1][1],objWidth[1][1],objHeight[1][1],vOffset[1][1],hOffset[1][1], color_o[1][1], upEnable[1][1], downEnable[1][1], leftEnable[1][1], rightEnable[1][1]);
+       Rectangle wall_1_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos1,rect3_hStartPos1,rectWidth,rectHeight,vStartPos[2][1],hStartPos[2][1],objWidth[2][1],objHeight[2][1],vOffset[2][1],hOffset[2][1], color_o[2][1], upEnable[2][1], downEnable[2][1], leftEnable[2][1], rightEnable[2][1]);
+//       Rectangle wall_1_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos1,rect4_hStartPos1,rectWidth,rectHeight,vStartPos[3][1],hStartPos[3][1],objWidth[3][1],objHeight[3][1],vOffset[3][1],hOffset[3][1], color_o[3][1], upEnable[3][1], downEnable[3][1], leftEnable[3][1], rightEnable[3][1]);  
     
 
      //=======================================================================================
@@ -161,10 +161,10 @@ output rightEnable[3:0][5:0]
            parameter rect4_vStartPos2=wall_vOffset2;
            parameter rect4_hStartPos2=4*wall_hOffset2;    
            
-           Rectangle wall_2_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos2,rect1_hStartPos2,rectWidth,rectHeight,vStartPos[0][2],hStartPos[0][2],objWidth[0][2],objHeight[0][2],vOffset[0][2],hOffset[0][2], color_o[0][2], upEnable[0][2], downEnable[0][2], leftEnable[0][2], rightEnable[0][2]);
-           Rectangle wall_2_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos2,rect2_hStartPos2,rectWidth,rectHeight,vStartPos[1][2],hStartPos[1][2],objWidth[1][2],objHeight[1][2],vOffset[1][2],hOffset[1][2], color_o[1][2], upEnable[1][2], downEnable[1][2], leftEnable[1][2], rightEnable[1][2]);
-           Rectangle wall_2_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos2,rect3_hStartPos2,rectWidth,rectHeight,vStartPos[2][2],hStartPos[2][2],objWidth[2][2],objHeight[2][2],vOffset[2][2],hOffset[2][2], color_o[2][2], upEnable[2][2], downEnable[2][2], leftEnable[2][2], rightEnable[2][2]);
-           Rectangle wall_2_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos2,rect4_hStartPos2,rectWidth,rectHeight,vStartPos[3][2],hStartPos[3][2],objWidth[3][2],objHeight[3][2],vOffset[3][2],hOffset[3][2], color_o[3][2], upEnable[3][2], downEnable[3][2], leftEnable[3][2], rightEnable[3][2]);  
+           Rectangle wall_2_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos2,rect1_hStartPos2,rectWidth,rectHeight,vStartPos[0][2],hStartPos[0][2],objWidth[0][2],objHeight[0][2],vOffset[0][2],hOffset[0][2], color_o[0][2], upEnable[0][2], downEnable[0][2], leftEnable[0][2], rightEnable[0][2]);
+           Rectangle wall_2_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos2,rect2_hStartPos2,rectWidth,rectHeight,vStartPos[1][2],hStartPos[1][2],objWidth[1][2],objHeight[1][2],vOffset[1][2],hOffset[1][2], color_o[1][2], upEnable[1][2], downEnable[1][2], leftEnable[1][2], rightEnable[1][2]);
+//           Rectangle wall_2_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos2,rect3_hStartPos2,rectWidth,rectHeight,vStartPos[2][2],hStartPos[2][2],objWidth[2][2],objHeight[2][2],vOffset[2][2],hOffset[2][2], color_o[2][2], upEnable[2][2], downEnable[2][2], leftEnable[2][2], rightEnable[2][2]);
+           Rectangle wall_2_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos2,rect4_hStartPos2,rectWidth,rectHeight,vStartPos[3][2],hStartPos[3][2],objWidth[3][2],objHeight[3][2],vOffset[3][2],hOffset[3][2], color_o[3][2], upEnable[3][2], downEnable[3][2], leftEnable[3][2], rightEnable[3][2]);  
      //=======================================================================================
      //WALL 3   
      //=======================================================================================
@@ -190,10 +190,10 @@ output rightEnable[3:0][5:0]
            parameter rect4_vStartPos3=wall_vOffset3;
            parameter rect4_hStartPos3=4*wall_hOffset3;    
            
-           Rectangle wall_3_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos3,rect1_hStartPos3,rectWidth,rectHeight,vStartPos[0][3],hStartPos[0][3],objWidth[0][3],objHeight[0][3],vOffset[0][3],hOffset[0][3], color_o[0][3], upEnable[0][3], downEnable[0][3], leftEnable[0][3], rightEnable[0][3]);
-           Rectangle wall_3_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos3,rect2_hStartPos3,rectWidth,rectHeight,vStartPos[1][3],hStartPos[1][3],objWidth[1][3],objHeight[1][3],vOffset[1][3],hOffset[1][3], color_o[1][3], upEnable[1][3], downEnable[1][3], leftEnable[1][3], rightEnable[1][3]);
-           Rectangle wall_3_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos3,rect3_hStartPos3,rectWidth,rectHeight,vStartPos[2][3],hStartPos[2][3],objWidth[2][3],objHeight[2][3],vOffset[2][3],hOffset[2][3], color_o[2][3], upEnable[2][3], downEnable[2][3], leftEnable[2][3], rightEnable[2][3]);
-           Rectangle wall_3_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos3,rect4_hStartPos3,rectWidth,rectHeight,vStartPos[3][3],hStartPos[3][3],objWidth[3][3],objHeight[3][3],vOffset[3][3],hOffset[3][3], color_o[3][3], upEnable[3][3], downEnable[3][3], leftEnable[3][3], rightEnable[3][3]);  
+           Rectangle wall_3_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos3,rect1_hStartPos3,rectWidth,rectHeight,vStartPos[0][3],hStartPos[0][3],objWidth[0][3],objHeight[0][3],vOffset[0][3],hOffset[0][3], color_o[0][3], upEnable[0][3], downEnable[0][3], leftEnable[0][3], rightEnable[0][3]);
+//           Rectangle wall_3_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos3,rect2_hStartPos3,rectWidth,rectHeight,vStartPos[1][3],hStartPos[1][3],objWidth[1][3],objHeight[1][3],vOffset[1][3],hOffset[1][3], color_o[1][3], upEnable[1][3], downEnable[1][3], leftEnable[1][3], rightEnable[1][3]);
+           Rectangle wall_3_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos3,rect3_hStartPos3,rectWidth,rectHeight,vStartPos[2][3],hStartPos[2][3],objWidth[2][3],objHeight[2][3],vOffset[2][3],hOffset[2][3], color_o[2][3], upEnable[2][3], downEnable[2][3], leftEnable[2][3], rightEnable[2][3]);
+           Rectangle wall_3_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos3,rect4_hStartPos3,rectWidth,rectHeight,vStartPos[3][3],hStartPos[3][3],objWidth[3][3],objHeight[3][3],vOffset[3][3],hOffset[3][3], color_o[3][3], upEnable[3][3], downEnable[3][3], leftEnable[3][3], rightEnable[3][3]);  
         
         //=======================================================================================
         //WALL 4   
@@ -220,10 +220,10 @@ output rightEnable[3:0][5:0]
               parameter rect4_vStartPos4=wall_vOffset4;
               parameter rect4_hStartPos4=4*wall_hOffset4;    
               
-              Rectangle wall_4_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos4,rect1_hStartPos4,rectWidth,rectHeight,vStartPos[0][4],hStartPos[0][4],objWidth[0][4],objHeight[0][4],vOffset[0][4],hOffset[0][4], color_o[0][4], upEnable[0][4], downEnable[0][4], leftEnable[0][4], rightEnable[0][4]);
-              Rectangle wall_4_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos4,rect2_hStartPos4,rectWidth,rectHeight,vStartPos[1][4],hStartPos[1][4],objWidth[1][4],objHeight[1][4],vOffset[1][4],hOffset[1][4], color_o[1][4], upEnable[1][4], downEnable[1][4], leftEnable[1][4], rightEnable[1][4]);
-              Rectangle wall_4_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos4,rect3_hStartPos4,rectWidth,rectHeight,vStartPos[2][4],hStartPos[2][4],objWidth[2][4],objHeight[2][4],vOffset[2][4],hOffset[2][4], color_o[2][4], upEnable[2][4], downEnable[2][4], leftEnable[2][4], rightEnable[2][4]);
-              Rectangle wall_4_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos4,rect4_hStartPos4,rectWidth,rectHeight,vStartPos[3][4],hStartPos[3][4],objWidth[3][4],objHeight[3][4],vOffset[3][4],hOffset[3][4], color_o[3][4], upEnable[3][4], downEnable[3][4], leftEnable[3][4], rightEnable[3][4]);  
+//              Rectangle wall_4_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos4,rect1_hStartPos4,rectWidth,rectHeight,vStartPos[0][4],hStartPos[0][4],objWidth[0][4],objHeight[0][4],vOffset[0][4],hOffset[0][4], color_o[0][4], upEnable[0][4], downEnable[0][4], leftEnable[0][4], rightEnable[0][4]);
+              Rectangle wall_4_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos4,rect2_hStartPos4,rectWidth,rectHeight,vStartPos[1][4],hStartPos[1][4],objWidth[1][4],objHeight[1][4],vOffset[1][4],hOffset[1][4], color_o[1][4], upEnable[1][4], downEnable[1][4], leftEnable[1][4], rightEnable[1][4]);
+              Rectangle wall_4_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos4,rect3_hStartPos4,rectWidth,rectHeight,vStartPos[2][4],hStartPos[2][4],objWidth[2][4],objHeight[2][4],vOffset[2][4],hOffset[2][4], color_o[2][4], upEnable[2][4], downEnable[2][4], leftEnable[2][4], rightEnable[2][4]);
+              Rectangle wall_4_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos4,rect4_hStartPos4,rectWidth,rectHeight,vStartPos[3][4],hStartPos[3][4],objWidth[3][4],objHeight[3][4],vOffset[3][4],hOffset[3][4], color_o[3][4], upEnable[3][4], downEnable[3][4], leftEnable[3][4], rightEnable[3][4]);  
 
         //=======================================================================================
         //WALL 5   
@@ -250,10 +250,10 @@ output rightEnable[3:0][5:0]
               parameter rect4_vStartPos5=wall_vOffset5;
               parameter rect4_hStartPos5=4*wall_hOffset5;    
               
-              Rectangle wall_5_rect_1(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos5,rect1_hStartPos5,rectWidth,rectHeight,vStartPos[0][5],hStartPos[0][5],objWidth[0][5],objHeight[0][5],vOffset[0][5],hOffset[0][5], color_o[0][5], upEnable[0][5], downEnable[0][5], leftEnable[0][5], rightEnable[0][5]);
-              Rectangle wall_5_rect_2(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos5,rect2_hStartPos5,rectWidth,rectHeight,vStartPos[1][5],hStartPos[1][5],objWidth[1][5],objHeight[1][5],vOffset[1][5],hOffset[1][5], color_o[1][5], upEnable[1][5], downEnable[1][5], leftEnable[1][5], rightEnable[1][5]);
-              Rectangle wall_5_rect_3(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos5,rect3_hStartPos5,rectWidth,rectHeight,vStartPos[2][5],hStartPos[2][5],objWidth[2][5],objHeight[2][5],vOffset[2][5],hOffset[2][5], color_o[2][5], upEnable[2][5], downEnable[2][5], leftEnable[2][5], rightEnable[2][5]);
-              Rectangle wall_5_rect_4(player_color, 4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos5,rect4_hStartPos5,rectWidth,rectHeight,vStartPos[3][5],hStartPos[3][5],objWidth[3][5],objHeight[3][5],vOffset[3][5],hOffset[3][5], color_o[3][5], upEnable[3][5], downEnable[3][5], leftEnable[3][5], rightEnable[3][5]);  
+              Rectangle wall_5_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos5,rect1_hStartPos5,rectWidth,rectHeight,vStartPos[0][5],hStartPos[0][5],objWidth[0][5],objHeight[0][5],vOffset[0][5],hOffset[0][5], color_o[0][5], upEnable[0][5], downEnable[0][5], leftEnable[0][5], rightEnable[0][5]);
+              Rectangle wall_5_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos5,rect2_hStartPos5,rectWidth,rectHeight,vStartPos[1][5],hStartPos[1][5],objWidth[1][5],objHeight[1][5],vOffset[1][5],hOffset[1][5], color_o[1][5], upEnable[1][5], downEnable[1][5], leftEnable[1][5], rightEnable[1][5]);
+              Rectangle wall_5_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos5,rect3_hStartPos5,rectWidth,rectHeight,vStartPos[2][5],hStartPos[2][5],objWidth[2][5],objHeight[2][5],vOffset[2][5],hOffset[2][5], color_o[2][5], upEnable[2][5], downEnable[2][5], leftEnable[2][5], rightEnable[2][5]);
+//              Rectangle wall_5_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos5,rect4_hStartPos5,rectWidth,rectHeight,vStartPos[3][5],hStartPos[3][5],objWidth[3][5],objHeight[3][5],vOffset[3][5],hOffset[3][5], color_o[3][5], upEnable[3][5], downEnable[3][5], leftEnable[3][5], rightEnable[3][5]);  
 
 //        //=======================================================================================
 //        //wall 6  

--- a/Obstacles.v
+++ b/Obstacles.v
@@ -130,10 +130,10 @@ output rightEnable[3:0][5:0]
        parameter rect4_vStartPos1=wall_vOffset1;
        parameter rect4_hStartPos1=4*wall_hOffset1;    
        
-       Rectangle wall_1_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos1,rect1_hStartPos1,rectWidth,rectHeight,vStartPos[0][1],hStartPos[0][1],objWidth[0][1],objHeight[0][1],vOffset[0][1],hOffset[0][1], color_o[0][1], upEnable[0][1], downEnable[0][1], leftEnable[0][1], rightEnable[0][1]);
+//       Rectangle wall_1_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos1,rect1_hStartPos1,rectWidth,rectHeight,vStartPos[0][1],hStartPos[0][1],objWidth[0][1],objHeight[0][1],vOffset[0][1],hOffset[0][1], color_o[0][1], upEnable[0][1], downEnable[0][1], leftEnable[0][1], rightEnable[0][1]);
        Rectangle wall_1_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos1,rect2_hStartPos1,rectWidth,rectHeight,vStartPos[1][1],hStartPos[1][1],objWidth[1][1],objHeight[1][1],vOffset[1][1],hOffset[1][1], color_o[1][1], upEnable[1][1], downEnable[1][1], leftEnable[1][1], rightEnable[1][1]);
        Rectangle wall_1_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos1,rect3_hStartPos1,rectWidth,rectHeight,vStartPos[2][1],hStartPos[2][1],objWidth[2][1],objHeight[2][1],vOffset[2][1],hOffset[2][1], color_o[2][1], upEnable[2][1], downEnable[2][1], leftEnable[2][1], rightEnable[2][1]);
-//       Rectangle wall_1_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos1,rect4_hStartPos1,rectWidth,rectHeight,vStartPos[3][1],hStartPos[3][1],objWidth[3][1],objHeight[3][1],vOffset[3][1],hOffset[3][1], color_o[3][1], upEnable[3][1], downEnable[3][1], leftEnable[3][1], rightEnable[3][1]);  
+       Rectangle wall_1_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos1,rect4_hStartPos1,rectWidth,rectHeight,vStartPos[3][1],hStartPos[3][1],objWidth[3][1],objHeight[3][1],vOffset[3][1],hOffset[3][1], color_o[3][1], upEnable[3][1], downEnable[3][1], leftEnable[3][1], rightEnable[3][1]);  
     
 
      //=======================================================================================
@@ -220,9 +220,9 @@ output rightEnable[3:0][5:0]
               parameter rect4_vStartPos4=wall_vOffset4;
               parameter rect4_hStartPos4=4*wall_hOffset4;    
               
-//              Rectangle wall_4_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos4,rect1_hStartPos4,rectWidth,rectHeight,vStartPos[0][4],hStartPos[0][4],objWidth[0][4],objHeight[0][4],vOffset[0][4],hOffset[0][4], color_o[0][4], upEnable[0][4], downEnable[0][4], leftEnable[0][4], rightEnable[0][4]);
+              Rectangle wall_4_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos4,rect1_hStartPos4,rectWidth,rectHeight,vStartPos[0][4],hStartPos[0][4],objWidth[0][4],objHeight[0][4],vOffset[0][4],hOffset[0][4], color_o[0][4], upEnable[0][4], downEnable[0][4], leftEnable[0][4], rightEnable[0][4]);
               Rectangle wall_4_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos4,rect2_hStartPos4,rectWidth,rectHeight,vStartPos[1][4],hStartPos[1][4],objWidth[1][4],objHeight[1][4],vOffset[1][4],hOffset[1][4], color_o[1][4], upEnable[1][4], downEnable[1][4], leftEnable[1][4], rightEnable[1][4]);
-              Rectangle wall_4_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos4,rect3_hStartPos4,rectWidth,rectHeight,vStartPos[2][4],hStartPos[2][4],objWidth[2][4],objHeight[2][4],vOffset[2][4],hOffset[2][4], color_o[2][4], upEnable[2][4], downEnable[2][4], leftEnable[2][4], rightEnable[2][4]);
+//              Rectangle wall_4_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos4,rect3_hStartPos4,rectWidth,rectHeight,vStartPos[2][4],hStartPos[2][4],objWidth[2][4],objHeight[2][4],vOffset[2][4],hOffset[2][4], color_o[2][4], upEnable[2][4], downEnable[2][4], leftEnable[2][4], rightEnable[2][4]);
               Rectangle wall_4_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos4,rect4_hStartPos4,rectWidth,rectHeight,vStartPos[3][4],hStartPos[3][4],objWidth[3][4],objHeight[3][4],vOffset[3][4],hOffset[3][4], color_o[3][4], upEnable[3][4], downEnable[3][4], leftEnable[3][4], rightEnable[3][4]);  
 
         //=======================================================================================
@@ -252,8 +252,8 @@ output rightEnable[3:0][5:0]
               
               Rectangle wall_5_rect_1(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos5,rect1_hStartPos5,rectWidth,rectHeight,vStartPos[0][5],hStartPos[0][5],objWidth[0][5],objHeight[0][5],vOffset[0][5],hOffset[0][5], color_o[0][5], upEnable[0][5], downEnable[0][5], leftEnable[0][5], rightEnable[0][5]);
               Rectangle wall_5_rect_2(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos5,rect2_hStartPos5,rectWidth,rectHeight,vStartPos[1][5],hStartPos[1][5],objWidth[1][5],objHeight[1][5],vOffset[1][5],hOffset[1][5], color_o[1][5], upEnable[1][5], downEnable[1][5], leftEnable[1][5], rightEnable[1][5]);
-              Rectangle wall_5_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos5,rect3_hStartPos5,rectWidth,rectHeight,vStartPos[2][5],hStartPos[2][5],objWidth[2][5],objHeight[2][5],vOffset[2][5],hOffset[2][5], color_o[2][5], upEnable[2][5], downEnable[2][5], leftEnable[2][5], rightEnable[2][5]);
-//              Rectangle wall_5_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos5,rect4_hStartPos5,rectWidth,rectHeight,vStartPos[3][5],hStartPos[3][5],objWidth[3][5],objHeight[3][5],vOffset[3][5],hOffset[3][5], color_o[3][5], upEnable[3][5], downEnable[3][5], leftEnable[3][5], rightEnable[3][5]);  
+//              Rectangle wall_5_rect_3(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos5,rect3_hStartPos5,rectWidth,rectHeight,vStartPos[2][5],hStartPos[2][5],objWidth[2][5],objHeight[2][5],vOffset[2][5],hOffset[2][5], color_o[2][5], upEnable[2][5], downEnable[2][5], leftEnable[2][5], rightEnable[2][5]);
+              Rectangle wall_5_rect_4(player_color, 4'd6,1'd0,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos5,rect4_hStartPos5,rectWidth,rectHeight,vStartPos[3][5],hStartPos[3][5],objWidth[3][5],objHeight[3][5],vOffset[3][5],hOffset[3][5], color_o[3][5], upEnable[3][5], downEnable[3][5], leftEnable[3][5], rightEnable[3][5]);  
 
 //        //=======================================================================================
 //        //wall 6  

--- a/Obstacles.v
+++ b/Obstacles.v
@@ -21,9 +21,6 @@
 
 
 module Obstacles(
-
-
-// testing the branch
 input [31:0] player_hPos,
 input [31:0] player_vPos,
 input [3:0] player_color,
@@ -283,10 +280,17 @@ output rightEnable[3:0][5:0]
 //              parameter rect4_vStartPos6=wall_vOffset6;
 //              parameter rect4_hStartPos6=4*wall_hOffset6;    
               
+
 //              Rectangle wall_6_rect_1(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos6,rect1_hStartPos6,rectWidth,rectHeight,vStartPos[0][6],hStartPos[0][6],objWidth[0][6],objHeight[0][6],vOffset[0][6],hOffset[0][6], color_o[0][6]);
 //             Rectangle wall_6_rect_2(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos6,rect2_hStartPos6,rectWidth,rectHeight,vStartPos[1][6],hStartPos[1][6],objWidth[1][6],objHeight[1][6],vOffset[1][6],hOffset[1][6], color_o[1][6]);
 //              Rectangle wall_6_rect_3(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos6,rect3_hStartPos6,rectWidth,rectHeight,vStartPos[2][6],hStartPos[2][6],objWidth[2][6],objHeight[2][6],vOffset[2][6],hOffset[2][6], color_o[2][6]);
 //              Rectangle wall_6_rect_4(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos6,rect4_hStartPos6,rectWidth,rectHeight,vStartPos[3][6],hStartPos[3][6],objWidth[3][6],objHeight[3][6],vOffset[3][6],hOffset[3][6], color_o[3][6]);  
+
+//              Rectangle wall_6_rect_1(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect1_vStartPos6,rect1_hStartPos6,rectWidth,rectHeight,vStartPos[0][6],hStartPos[0][6],objWidth[0][6],objHeight[0][6],vOffset[0][6],hOffset[0][6], color_o[0][6]);
+//              Rectangle wall_6_rect_2(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect2_vStartPos6,rect2_hStartPos6,rectWidth,rectHeight,vStartPos[1][6],hStartPos[1][6],objWidth[1][6],objHeight[1][6],vOffset[1][6],hOffset[1][6], color_o[1][6]);
+//              Rectangle wall_6_rect_3(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect3_vStartPos6,rect3_hStartPos6,rectWidth,rectHeight,vStartPos[2][6],hStartPos[2][6],objWidth[2][6],objHeight[2][6],vOffset[2][6],hOffset[2][6], color_o[2][6]);
+//              Rectangle wall_6_rect_4(4'd6,1'd1,player_hPos,player_vPos,rst,btnClk,4'd0,rect4_vStartPos6,rect4_hStartPos6,rectWidth,rectHeight,vStartPos[3][6],hStartPos[3][6],objWidth[3][6],objHeight[3][6],vOffset[3][6],hOffset[3][6], color_o[3][6]);  
+
 
 
 endmodule

--- a/Rectangle.v
+++ b/Rectangle.v
@@ -134,6 +134,7 @@ always@(posedge btnClk, posedge rst) begin
     if((player_hPos==hStartPos+objWidth)            //player left edge is on rectangles right edge
     &&(player_vPos>=vStartPos+vOffset)             //player top edge is not above rectangle top edge
     &&(player_vPos+12<=vStartPos+vOffset+objWidth)           //player bottom edge is not below rectangle top edge
+   &&(rect_color!=player_color)                             //disable only if colors dont match
     ) 
     begin 
         leftEnable<=1'b0;
@@ -143,7 +144,9 @@ always@(posedge btnClk, posedge rst) begin
     if((player_hPos+12==hStartPos)                    //player right edge is on rectangles left edge
     &&(player_vPos>=vStartPos+vOffset)                      //player top edge is not above rectangle top edge
     &&(player_vPos+12<=vStartPos+vOffset+objWidth)           //player bottom edge is not below rectangle top edge
+   &&(rect_color!=player_color)                             //disable only if colors dont match
     ) 
+    
     begin 
         rightEnable<=1'b0;
     end

--- a/Rectangle.v
+++ b/Rectangle.v
@@ -98,7 +98,7 @@ always@(posedge btnClk, posedge rst) begin
     &&  (player_vPos+objHeight==vStartPos+vOffset)                                      //player is on top border of rectangle 
     && (rect_color!=player_color) )                                             //not color match 
     begin
-        downEnable <= 1'b0; //disable downButton
+        downEnable <= 1'b1; //disable downButton
     end 
     else if(((player_hPos<hStartPos+hOffset&&player_hPos+12>hStartPos+hOffset)        //player is on left edge of rectangle
     ||(player_hPos<hStartPos+hOffset+objWidth&&player_hPos+12>hStartPos+hOffset+objWidth))      // is on right edge of rectangle
@@ -109,7 +109,7 @@ always@(posedge btnClk, posedge rst) begin
     end
     else
     begin  
-        downEnable <= 1'b1;  //enable downButton
+        downEnable <= 1'b0;  //enable downButton
     end
     
      //UP DISABLE
@@ -117,18 +117,18 @@ always@(posedge btnClk, posedge rst) begin
     && (player_vPos==vStartPos+vOffset+objHeight)                                          //player is on bottom border of rectangle       
     && (rect_color!=player_color) )                                                  //not color match 
     begin
-        upEnable <= 1'b0; //disable upButton
+        upEnable <= 1'b1; //disable upButton
     end
     else if(((player_hPos<hStartPos+hOffset&&player_hPos+objHeight>hStartPos+hOffset)        //player is on left edge of rectangle
     ||(player_hPos<hStartPos+hOffset+objWidth&&player_hPos+objHeight>hStartPos+hOffset+objWidth))      // is on right edge of rectangle
         && (player_vPos==vStartPos+vOffset+objHeight)                                         //player is on bottom border of rectangle  
          )                                                 
     begin
-        upEnable <= 1'b0; //disable upButton
+        upEnable <= 1'b1; //disable upButton
     end    
     else 
     begin 
-        upEnable <= 1'b1;  //enable upButton      
+        upEnable <= 1'b0;  //enable upButton      
     end
     //Left Disable
     if((player_hPos==hStartPos+objWidth)            //player left edge is on rectangles right edge
@@ -137,9 +137,9 @@ always@(posedge btnClk, posedge rst) begin
    &&(rect_color!=player_color)                             //disable only if colors dont match
     ) 
     begin 
-        leftEnable<=1'b0;
+        leftEnable<=1'b1;
     end
-    else leftEnable<=1'b1;
+    else leftEnable<=1'b0;
         //right Disable
     if((player_hPos+12==hStartPos)                    //player right edge is on rectangles left edge
     &&(player_vPos>=vStartPos+vOffset)                      //player top edge is not above rectangle top edge
@@ -148,9 +148,9 @@ always@(posedge btnClk, posedge rst) begin
     ) 
     
     begin 
-        rightEnable<=1'b0;
+        rightEnable<=1'b1;
     end
-    else rightEnable<=1'b1;
+    else rightEnable<=1'b0;
     
 //     // LEFT/RIGHT ENABLE/DISABLE -- "if hit by diff color"
 //   if((player_vPos == vStartPos + vOffset) // inside rectangle

--- a/Rectangle.v
+++ b/Rectangle.v
@@ -105,7 +105,7 @@ always@(posedge btnClk, posedge rst) begin
         &&  (player_vPos+12==vStartPos+vOffset)                                      //player is on top border of rectangle 
          )                                                  
     begin
-        downEnable <= 1'b0; //disable downButton
+        downEnable <= 1'b1; //disable downButton
     end
     else
     begin  

--- a/Rectangle.v
+++ b/Rectangle.v
@@ -42,8 +42,8 @@ module Rectangle(
     output [3:0] rect_color_o,
     output reg upEnable,
     output reg downEnable,
-    output   leftEnable,
-    output   rightEnable
+    output  reg leftEnable,
+    output  reg rightEnable
 );
 
 
@@ -55,6 +55,7 @@ assign objWidth_o=objWidth;
 assign objHeight_o=objHeight;
 
 //update objects location
+
 
 always@(posedge btnClk, posedge rst) begin
 
@@ -92,15 +93,15 @@ always@(posedge btnClk, posedge rst) begin
         
     endcase   
         
-    // DOWN ENABLE/DISABLE
-    if((player_hPos>=hStartPos+hOffset&&player_hPos+12<=hStartPos+hOffset+128)    // player is between left and right edges of this rectangle
-    &&  (player_vPos+12==vStartPos+vOffset)                                      //player is on top border of rectangle 
+    // DOWN DISABLE
+    if((player_hPos>=hStartPos+hOffset&&player_hPos+12<=hStartPos+hOffset+objWidth)    // player is between left and right edges of this rectangle
+    &&  (player_vPos+objHeight==vStartPos+vOffset)                                      //player is on top border of rectangle 
     && (rect_color!=player_color) )                                             //not color match 
     begin
         downEnable <= 1'b0; //disable downButton
     end 
     else if(((player_hPos<hStartPos+hOffset&&player_hPos+12>hStartPos+hOffset)        //player is on left edge of rectangle
-    ||(player_hPos<hStartPos+hOffset+128&&player_hPos+12>hStartPos+hOffset+128))      // is on right edge of rectangle
+    ||(player_hPos<hStartPos+hOffset+objWidth&&player_hPos+12>hStartPos+hOffset+objWidth))      // is on right edge of rectangle
         &&  (player_vPos+12==vStartPos+vOffset)                                      //player is on top border of rectangle 
          )                                                  
     begin
@@ -111,16 +112,16 @@ always@(posedge btnClk, posedge rst) begin
         downEnable <= 1'b1;  //enable downButton
     end
     
-     //UP ENABLE/DISABLE
-    if((player_hPos>=hStartPos+hOffset&&player_hPos+12<=hStartPos+hOffset+128)      // player is between left and right edges of this rectangle
-    && (player_vPos==vStartPos+vOffset+12)                                          //player is on bottom border of rectangle       
+     //UP DISABLE
+    if((player_hPos>=hStartPos+hOffset&&player_hPos+12<=hStartPos+hOffset+objWidth)      // player is between left and right edges of this rectangle
+    && (player_vPos==vStartPos+vOffset+objHeight)                                          //player is on bottom border of rectangle       
     && (rect_color!=player_color) )                                                  //not color match 
     begin
         upEnable <= 1'b0; //disable upButton
     end
-    else if(((player_hPos<hStartPos+hOffset&&player_hPos+12>hStartPos+hOffset)        //player is on left edge of rectangle
-    ||(player_hPos<hStartPos+hOffset+128&&player_hPos+12>hStartPos+hOffset+128))      // is on right edge of rectangle
-        && (player_vPos==vStartPos+vOffset+12)                                         //player is on bottom border of rectangle  
+    else if(((player_hPos<hStartPos+hOffset&&player_hPos+objHeight>hStartPos+hOffset)        //player is on left edge of rectangle
+    ||(player_hPos<hStartPos+hOffset+objWidth&&player_hPos+objHeight>hStartPos+hOffset+objWidth))      // is on right edge of rectangle
+        && (player_vPos==vStartPos+vOffset+objHeight)                                         //player is on bottom border of rectangle  
          )                                                 
     begin
         upEnable <= 1'b0; //disable upButton
@@ -129,10 +130,29 @@ always@(posedge btnClk, posedge rst) begin
     begin 
         upEnable <= 1'b1;  //enable upButton      
     end
-//     // LEFT/RIGHT ENBLE/DISABLE
+    //Left Disable
+    if((player_hPos==hStartPos+objWidth)            //player left edge is on rectangles right edge
+    &&(player_vPos>=vStartPos+vOffset)             //player top edge is not above rectangle top edge
+    &&(player_vPos+12<=vStartPos+vOffset+objWidth)           //player bottom edge is not below rectangle top edge
+    ) 
+    begin 
+        leftEnable<=1'b0;
+    end
+    else leftEnable<=1'b1;
+        //right Disable
+    if((player_hPos+12==hStartPos)                    //player right edge is on rectangles left edge
+    &&(player_vPos>=vStartPos+vOffset)                      //player top edge is not above rectangle top edge
+    &&(player_vPos+12<=vStartPos+vOffset+objWidth)           //player bottom edge is not below rectangle top edge
+    ) 
+    begin 
+        rightEnable<=1'b0;
+    end
+    else rightEnable<=1'b1;
+    
+//     // LEFT/RIGHT ENABLE/DISABLE -- "if hit by diff color"
 //   if((player_vPos == vStartPos + vOffset) // inside rectangle
-//   && (((player_hPos < hStartPos + hOffset) && ( player_hPos + 12 > hStartPos + hOffset)) // left side of block is inside player
-//   || ((player_hPos < hStartPos + hOffset + 128) && ( player_hPos + 12 > hStartPos + hOffset + 128))) // right side of block
+//   && (((player_hPos < hStartPos + hOffset) && ( player_hPos + objHeight > hStartPos + hOffset)) // left side of block is inside player
+//   || ((player_hPos < hStartPos + hOffset + objWidth) && ( player_hPos + objHeight > hStartPos + hOffset + objWidth))) // right side of block
 //   && ((rect_color != player_color)))
 //   begin
 //       // Disable Controls
@@ -141,6 +161,21 @@ always@(posedge btnClk, posedge rst) begin
 //       leftEnable <= 1'b0;
 //       rightEnable <= 1'b0; 
 //   end
+//   else
+//   begin
+//        //Enable Controls
+//       downEnable <= 1'b1;
+//       upEnable <= 1'b1;
+//       leftEnable <= 1'b1;
+//       rightEnable <= 1'b1;       
+//    end
+   
+
+    
+    
+   
+   
+  
 end
 end
 

--- a/VideoController.v
+++ b/VideoController.v
@@ -22,7 +22,8 @@
 
 module VideoController(
 input [3:0] player_color,
-input [3:0] wall_color,
+input [3:0] wall_color [3:0][5:0],
+input [3:0] scroll_color [3:0][5:0],
 
     input clk,
     input rst,
@@ -143,10 +144,7 @@ input [3:0] player_color,
 
 output reg [2:0] Sel
 );*/
-    CompareDisp M6(
-
-
-    
+    CompareDisp M6(    
     hCount_w,
     vCount_w,
     btns,
@@ -171,7 +169,8 @@ output reg [2:0] Sel
     player_vOffset ,      
     player_hOffset, 
         player_color,
-        wall_color,   
+        wall_color, 
+        scroll_color,  
     Sel_w);
     
 //    module Mux(

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -28,8 +28,8 @@ module enableCompare(
     
     output reg upEnable_o,
     output reg downEnable_o,
-    output  leftEnable_o,
-    output   rightEnable_o
+    output  reg leftEnable_o,
+    output   reg rightEnable_o
 
 );
 

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -26,7 +26,7 @@ module enableCompare(
     input leftEnable[3:0][5:0],
     input rightEnable[3:0][5:0],
     //wall
-        input wall_upEnable[3:0][5:0],
+    input wall_upEnable[3:0][5:0],
     input wall_downEnable[3:0][5:0],
     input wall_leftEnable[3:0][5:0],
     input wall_rightEnable[3:0][5:0],
@@ -47,6 +47,11 @@ reg [23:0] upEnable_all;
 reg [23:0] downEnable_all;
 reg [23:0] leftEnable_all;
 reg [23:0] rightEnable_all;
+
+reg [23:0] wall_upEnable_all; 
+reg [23:0] wall_downEnable_all;
+reg [23:0] wall_leftEnable_all;
+reg [23:0] wall_rightEnable_all;
 
 always@(*) begin
 //DOWN ENABLE
@@ -179,19 +184,219 @@ downEnable_all[23]<=downEnable[3][5];
     rightEnable_all[21]<=rightEnable[1][5];
     rightEnable_all[22]<=rightEnable[2][5];
     rightEnable_all[23]<=rightEnable[3][5];  
-    
-    
+
+//DOWN ENABLE
+//scroll 0
+downEnable_all[0]<=downEnable[0][0];
+downEnable_all[1]<=downEnable[1][0];
+downEnable_all[2]<=downEnable[2][0];
+downEnable_all[3]<=downEnable[3][0];
+//scroll 1
+downEnable_all[4]<=downEnable[0][1];
+downEnable_all[5]<=downEnable[1][1];
+downEnable_all[6]<=downEnable[2][1];
+downEnable_all[7]<=downEnable[3][1];
+//scroll 2
+ downEnable_all[8]<=downEnable[0][2];    
+ downEnable_all[9]<=downEnable[1][2];
+downEnable_all[10]<=downEnable[2][2];
+downEnable_all[11]<=downEnable[3][2];
+//scroll 3
+downEnable_all[12]<=downEnable[0][3];
+downEnable_all[13]<=downEnable[1][3];
+downEnable_all[14]<=downEnable[2][3];
+downEnable_all[15]<=downEnable[3][3];
+//scroll 4
+downEnable_all[16]<=downEnable[0][4];    
+downEnable_all[17]<=downEnable[1][4];
+downEnable_all[18]<=downEnable[2][4];
+downEnable_all[19]<=downEnable[3][4];
+
+//scroll 5
+downEnable_all[20]<=downEnable[0][5];
+downEnable_all[21]<=downEnable[1][5];
+downEnable_all[22]<=downEnable[2][5];
+downEnable_all[23]<=downEnable[3][5];  
+    // UP ENABLE 
+  //scroll 0
+  upEnable_all[0]<=upEnable[0][0];
+  upEnable_all[1]<=upEnable[1][0];
+  upEnable_all[2]<=upEnable[2][0];
+  upEnable_all[3]<=upEnable[3][0];
+  //scroll 1
+  upEnable_all[4]<=upEnable[0][1];
+  upEnable_all[5]<=upEnable[1][1];
+  upEnable_all[6]<=upEnable[2][1];
+  upEnable_all[7]<=upEnable[3][1];
+  //scroll 2
+   upEnable_all[8]<=upEnable[0][2];    
+   upEnable_all[9]<=upEnable[1][2];
+  upEnable_all[10]<=upEnable[2][2];
+  upEnable_all[11]<=upEnable[3][2];
+  //scroll 3
+  upEnable_all[12]<=upEnable[0][3];
+  upEnable_all[13]<=upEnable[1][3];
+  upEnable_all[14]<=upEnable[2][3];
+  upEnable_all[15]<=upEnable[3][3];
+  //scroll 4
+  upEnable_all[16]<=upEnable[0][4];    
+  upEnable_all[17]<=upEnable[1][4];
+  upEnable_all[18]<=upEnable[2][4];
+  upEnable_all[19]<=upEnable[3][4];
+
+  //scroll 5
+  upEnable_all[20]<=upEnable[0][5];
+  upEnable_all[21]<=upEnable[1][5];
+  upEnable_all[22]<=upEnable[2][5];
+  upEnable_all[23]<=upEnable[3][5];  
+
+//==============================================
+//WALL
+//==============================================
+//DOWN ENABLE
+//wall 0
+wall_downEnable_all[0]<=wall_downEnable[0][0];
+wall_downEnable_all[1]<=wall_downEnable[1][0];
+wall_downEnable_all[2]<=wall_downEnable[2][0];
+wall_downEnable_all[3]<=wall_downEnable[3][0];
+//wall 1
+wall_downEnable_all[4]<=wall_downEnable[0][1];
+wall_downEnable_all[5]<=wall_downEnable[1][1];
+wall_downEnable_all[6]<=wall_downEnable[2][1];
+wall_downEnable_all[7]<=wall_downEnable[3][1];
+//wall 2
+ wall_downEnable_all[8]<=wall_downEnable[0][2];    
+ wall_downEnable_all[9]<=wall_downEnable[1][2];
+wall_downEnable_all[10]<=wall_downEnable[2][2];
+wall_downEnable_all[11]<=wall_downEnable[3][2];
+//wall 3
+wall_downEnable_all[12]<=wall_downEnable[0][3];
+wall_downEnable_all[13]<=wall_downEnable[1][3];
+wall_downEnable_all[14]<=wall_downEnable[2][3];
+wall_downEnable_all[15]<=wall_downEnable[3][3];
+//wall 4
+wall_downEnable_all[16]<=wall_downEnable[0][4];    
+wall_downEnable_all[17]<=wall_downEnable[1][4];
+wall_downEnable_all[18]<=wall_downEnable[2][4];
+wall_downEnable_all[19]<=wall_downEnable[3][4];
+
+//wall 5
+wall_downEnable_all[20]<=wall_downEnable[0][5];
+wall_downEnable_all[21]<=wall_downEnable[1][5];
+wall_downEnable_all[22]<=wall_downEnable[2][5];
+wall_downEnable_all[23]<=wall_downEnable[3][5];  
+    // UP ENABLE 
+  //wall 0
+  wall_upEnable_all[0]<=wall_upEnable[0][0];
+  wall_upEnable_all[1]<=wall_upEnable[1][0];
+  wall_upEnable_all[2]<=wall_upEnable[2][0];
+  wall_upEnable_all[3]<=wall_upEnable[3][0];
+  //wall 1
+  wall_upEnable_all[4]<=wall_upEnable[0][1];
+  wall_upEnable_all[5]<=wall_upEnable[1][1];
+  wall_upEnable_all[6]<=wall_upEnable[2][1];
+  wall_upEnable_all[7]<=wall_upEnable[3][1];
+  //wall 2
+   wall_upEnable_all[8]<=wall_upEnable[0][2];    
+   wall_upEnable_all[9]<=wall_upEnable[1][2];
+  wall_upEnable_all[10]<=wall_upEnable[2][2];
+  wall_upEnable_all[11]<=wall_upEnable[3][2];
+  //wall 3
+  wall_upEnable_all[12]<=wall_upEnable[0][3];
+  wall_upEnable_all[13]<=wall_upEnable[1][3];
+  wall_upEnable_all[14]<=wall_upEnable[2][3];
+  wall_upEnable_all[15]<=wall_upEnable[3][3];
+  //wall 4
+  wall_upEnable_all[16]<=wall_upEnable[0][4];    
+  wall_upEnable_all[17]<=wall_upEnable[1][4];
+  wall_upEnable_all[18]<=wall_upEnable[2][4];
+  wall_upEnable_all[19]<=wall_upEnable[3][4];
+
+  //wall 5
+  wall_upEnable_all[20]<=wall_upEnable[0][5];
+  wall_upEnable_all[21]<=wall_upEnable[1][5];
+  wall_upEnable_all[22]<=wall_upEnable[2][5];
+  wall_upEnable_all[23]<=wall_upEnable[3][5];  
+
+
+
+// LEFT ENABLE 
+    //wall 0
+    wall_leftEnable_all[0]<=wall_leftEnable[0][0];
+    wall_leftEnable_all[1]<=wall_leftEnable[1][0];
+    wall_leftEnable_all[2]<=wall_leftEnable[2][0];
+    wall_leftEnable_all[3]<=wall_leftEnable[3][0];
+    //wall 1
+    wall_leftEnable_all[4]<=wall_leftEnable[0][1];
+    wall_leftEnable_all[5]<=wall_leftEnable[1][1];
+    wall_leftEnable_all[6]<=wall_leftEnable[2][1];
+    wall_leftEnable_all[7]<=wall_leftEnable[3][1];
+    //wall 2
+    wall_leftEnable_all [8]<=wall_leftEnable[0][2];    
+    wall_leftEnable_all [9]<=wall_leftEnable[1][2];
+    wall_leftEnable_all[10]<=wall_leftEnable[2][2];
+    wall_leftEnable_all[11]<=wall_leftEnable[3][2];
+    //wall 3
+    wall_leftEnable_all[12]<=wall_leftEnable[0][3];
+    wall_leftEnable_all[13]<=wall_leftEnable[1][3];
+    wall_leftEnable_all[14]<=wall_leftEnable[2][3];
+    wall_leftEnable_all[15]<=wall_leftEnable[3][3];
+    //wall 4
+    wall_leftEnable_all[16]<=wall_leftEnable[0][4];    
+    wall_leftEnable_all[17]<=wall_leftEnable[1][4];
+    wall_leftEnable_all[18]<=wall_leftEnable[2][4];
+    wall_leftEnable_all[19]<=wall_leftEnable[3][4];
+    //wall 5
+    wall_leftEnable_all[20]<=wall_leftEnable[0][5];
+    wall_leftEnable_all[21]<=wall_leftEnable[1][5];
+    wall_leftEnable_all[22]<=wall_leftEnable[2][5];
+    wall_leftEnable_all[23]<=wall_leftEnable[3][5];  
+  
+// RIGHT ENABLE 
+    //wall 0
+    wall_rightEnable_all[0]<=wall_rightEnable[0][0];
+    wall_rightEnable_all[1]<=wall_rightEnable[1][0];
+    wall_rightEnable_all[2]<=wall_rightEnable[2][0];
+    wall_rightEnable_all[3]<=wall_rightEnable[3][0];
+    //wall 1
+    wall_rightEnable_all[4]<=wall_rightEnable[0][1];
+    wall_rightEnable_all[5]<=wall_rightEnable[1][1];
+    wall_rightEnable_all[6]<=wall_rightEnable[2][1];
+    wall_rightEnable_all[7]<=wall_rightEnable[3][1];
+    //wall 2
+    wall_rightEnable_all [8]<=wall_rightEnable[0][2];    
+    wall_rightEnable_all [9]<=wall_rightEnable[1][2];
+    wall_rightEnable_all[10]<=wall_rightEnable[2][2];
+    wall_rightEnable_all[11]<=wall_rightEnable[3][2];
+    //wall 3
+    wall_rightEnable_all[12]<=wall_rightEnable[0][3];
+    wall_rightEnable_all[13]<=wall_rightEnable[1][3];
+    wall_rightEnable_all[14]<=wall_rightEnable[2][3];
+    wall_rightEnable_all[15]<=wall_rightEnable[3][3];
+    //wall 4
+    wall_rightEnable_all[16]<=wall_rightEnable[0][4];    
+    wall_rightEnable_all[17]<=wall_rightEnable[1][4];
+    wall_rightEnable_all[18]<=wall_rightEnable[2][4];
+    wall_rightEnable_all[19]<=wall_rightEnable[3][4];
+    //wall 5
+    wall_rightEnable_all[20]<=wall_rightEnable[0][5];
+    wall_rightEnable_all[21]<=wall_rightEnable[1][5];
+    wall_rightEnable_all[22]<=wall_rightEnable[2][5];
+    wall_rightEnable_all[23]<=wall_rightEnable[3][5];  
+
+
+
 //enable/disable down    
-    if(downEnable_all == 24'hFFFFFF)        downEnable_o <= 1;
+    if(downEnable_all == 24'h0&&wall_downEnable_all == 24'h0)        downEnable_o <= 0;
     else        downEnable_o <= 0;
 //enable/disable up    
-    if(upEnable_all == 24'hFFFFFF)      upEnable_o <= 1;
+    if(upEnable_all == 24'h0&&wall_upEnable_all == 24'h0)      upEnable_o <= 1;
     else      upEnable_o <= 0;
 //enable/disable down    
-    if(leftEnable_all == 24'hFFFFFF)        leftEnable_o <= 1;
+    if(leftEnable_all == 24'h0&&wall_leftEnable_all == 24'h0)        leftEnable_o <= 1;
     else        leftEnable_o <= 0;
 //enable/disable up    
-    if(rightEnable_all == 24'hFFFFFF)      rightEnable_o <= 1;
+    if(rightEnable_all == 24'h0&&wall_rightEnable_all == 24'h0)      rightEnable_o <= 1;
     else      rightEnable_o <= 0;
     
 end

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -35,8 +35,8 @@ module enableCompare(
 
 //assign up_Enable=1'b1;
 //assign down_Enable=1'b1;
-assign leftEnable_o=1'b1;
-assign rightEnable_o=1'b1;
+//assign leftEnable_o=1'b1;
+//assign rightEnable_o=1'b1;
 
 reg [23:0] upEnable_all; 
 reg [23:0] downEnable_all;
@@ -182,12 +182,12 @@ downEnable_all[23]<=downEnable[3][5];
 //enable/disable up    
     if(upEnable_all == 24'hFFFFFF)      upEnable_o <= 1;
     else      upEnable_o <= 0;
-////enable/disable down    
-//    if(leftEnable_all == 24'hFFFFFF)        leftEnable_o <= 1;
-//    else        leftEnable_o <= 0;
-////enable/disable up    
-//    if(rightEnable_all == 24'hFFFFFF)      rightEnable_o <= 1;
-//    else      rightEnable_o <= 0;
+//enable/disable down    
+    if(leftEnable_all == 24'hFFFFFF)        leftEnable_o <= 1;
+    else        leftEnable_o <= 0;
+//enable/disable up    
+    if(rightEnable_all == 24'hFFFFFF)      rightEnable_o <= 1;
+    else      rightEnable_o <= 0;
     
 end
 endmodule

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -387,7 +387,7 @@ wall_downEnable_all[23]<=wall_downEnable[3][5];
 
 
 //enable/disable down    
-    if(downEnable_all == 24'h0&&wall_downEnable_all == 24'h0)        downEnable_o <= 0;
+    if(downEnable_all == 24'h0&&wall_downEnable_all == 24'h0)        downEnable_o <= 1;
     else        downEnable_o <= 0;
 //enable/disable up    
     if(upEnable_all == 24'h0&&wall_upEnable_all == 24'h0)      upEnable_o <= 1;

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -35,8 +35,8 @@ module enableCompare(
 
 //assign up_Enable=1'b1;
 //assign down_Enable=1'b1;
-//assign leftEnable_o=1'b1;
-//assign rightEnable_o=1'b1;
+assign leftEnable_o=1'b1;
+assign rightEnable_o=1'b1;
 
 reg [23:0] upEnable_all; 
 reg [23:0] downEnable_all;
@@ -182,12 +182,12 @@ downEnable_all[23]<=downEnable[3][5];
 //enable/disable up    
     if(upEnable_all == 24'hFFFFFF)      upEnable_o <= 1;
     else      upEnable_o <= 0;
-//enable/disable down    
-    if(leftEnable_all == 24'hFFFFFF)        leftEnable_o <= 1;
-    else        leftEnable_o <= 0;
-//enable/disable up    
-    if(rightEnable_all == 24'hFFFFFF)      rightEnable_o <= 1;
-    else      rightEnable_o <= 0;
+////enable/disable down    
+//    if(leftEnable_all == 24'hFFFFFF)        leftEnable_o <= 1;
+//    else        leftEnable_o <= 0;
+////enable/disable up    
+//    if(rightEnable_all == 24'hFFFFFF)      rightEnable_o <= 1;
+//    else      rightEnable_o <= 0;
     
 end
 endmodule

--- a/enableCompare.v
+++ b/enableCompare.v
@@ -25,6 +25,11 @@ module enableCompare(
     input downEnable[3:0][5:0],
     input leftEnable[3:0][5:0],
     input rightEnable[3:0][5:0],
+    //wall
+        input wall_upEnable[3:0][5:0],
+    input wall_downEnable[3:0][5:0],
+    input wall_leftEnable[3:0][5:0],
+    input wall_rightEnable[3:0][5:0],
     
     output reg upEnable_o,
     output reg downEnable_o,


### PR DESCRIPTION
get latest code:
-left and right disables occur at edges of mismatch color rectangles
-walls display and are recognized as barriers
-walls are discontinuous
-enable=0 instead of 1 like it used to be